### PR TITLE
Add missing commas in neovim's config

### DIFF
--- a/docs/resources/configure.md
+++ b/docs/resources/configure.md
@@ -34,7 +34,7 @@ endif
 
 ```lua
 vim.api.nvim_create_autocmd({ "BufEnter" }, {
-  pattern = { "*.bb" "*.bbappend" "*.bbclass" "*.inc" "conf/*.conf" },
+  pattern = { "*.bb", "*.bbappend", "*.bbclass", "*.inc", "conf/*.conf" },
   callback = function()
     vim.lsp.start({
       name = "bitbake",


### PR DESCRIPTION
This change fixes:

E5107: Error loading lua [string ":lua"]:48: '}' expected near '"*.bbappend"'